### PR TITLE
Jl/use afero virtual fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GoDotEnv ![CI](https://github.com/joho/godotenv/workflows/CI/badge.svg) [![Go Report Card](https://goreportcard.com/badge/github.com/joho/godotenv)](https://goreportcard.com/report/github.com/joho/godotenv)
 
+Exactly the same as the upstream godotenv, only allows passing in an in-memory filesystem via afero lib
+for easier unit tests.
+
 A Go (golang) port of the Ruby [dotenv](https://github.com/bkeepers/dotenv) project (which loads env vars from a .env file).
 
 From the original Library:

--- a/autoload/autoload.go
+++ b/autoload/autoload.go
@@ -8,8 +8,12 @@ package autoload
 	And bob's your mother's brother
 */
 
-import "github.com/joho/godotenv"
+import (
+	"github.com/joho/godotenv"
+	"github.com/spf13/afero"
+)
 
 func init() {
-	godotenv.Load()
+	fs := afero.NewOsFs()
+	godotenv.Load(fs)
 }

--- a/cmd/godotenv/cmd.go
+++ b/cmd/godotenv/cmd.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/joho/godotenv"
+	"github.com/spf13/afero"
 )
 
 func main() {
@@ -48,7 +49,7 @@ example
 	cmd := args[0]
 	cmdArgs := args[1:]
 
-	err := godotenv.Exec(envFilenames, cmd, cmdArgs, overload)
+	err := godotenv.Exec(afero.NewOsFs(), envFilenames, cmd, cmdArgs, overload)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,21 @@
 module github.com/joho/godotenv
 
-go 1.12
+go 1.23.0
+
+toolchain go1.23.2
+
+require (
+	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/spf13/afero v1.14.0 // indirect
+	github.com/yuin/goldmark v1.4.13 // indirect
+	golang.org/x/crypto v0.23.0 // indirect
+	golang.org/x/mod v0.17.0 // indirect
+	golang.org/x/net v0.25.0 // indirect
+	golang.org/x/sync v0.12.0 // indirect
+	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2 // indirect
+	golang.org/x/term v0.20.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=
+github.com/spf13/afero v1.14.0/go.mod h1:acJQ8t0ohCGuMN3O+Pv0V0hgMxNYDlvdk+VTfyZmbYo=
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2/go.mod h1:TeRTkGYfJXctD9OcfyVLyj2J3IxLnKwHJR8f4D8a3YE=
+golang.org/x/term v0.20.0/go.mod h1:8UkIAJTvZgivsXaD6/pH6U9ecQzZ45awqEOzuCvwpFY=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/godotenv.go
+++ b/godotenv.go
@@ -211,6 +211,10 @@ func readFile(fs afero.Fs, filename string) (envMap map[string]string, err error
 		return
 	}
 	defer file.Close()
+	fInfo, err := file.Stat()
+	if fInfo.IsDir() {
+		return nil, fmt.Errorf("readFile called on directory")
+	}
 
 	return Parse(file)
 }

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -25,7 +25,7 @@ func parseAndCompare(t *testing.T, rawEnvLine string, expectedKey string, expect
 	}
 }
 
-func loadEnvAndCompareValues(t *testing.T, fs afero.Fs, loader func(files ...string) error, envFileName string, expectedValues map[string]string, presets map[string]string) {
+func loadEnvAndCompareValues(t *testing.T, fs afero.Fs, loader func(fs afero.Fs, files ...string) error, envFileName string, expectedValues map[string]string, presets map[string]string) {
 	// first up, clear the env
 	os.Clearenv()
 


### PR DESCRIPTION
Adds a argument to all the functions that call the real filesystem directly to instead be able to use a virtual filesystem from Afero.

This makes it easier to use this library inside of code that uses an in-memory filesystem for testing.